### PR TITLE
Changes from background agent bc-936da927-4fb3-418e-814f-59f249479dee

### DIFF
--- a/WEBPHONE_ANALYSIS_AND_SOLUTION_2025-08-26.md
+++ b/WEBPHONE_ANALYSIS_AND_SOLUTION_2025-08-26.md
@@ -1,0 +1,244 @@
+# WebPhone Bridge Analysis and Solution - 26.08.2025
+
+## 🔴 КРИТИЧЕСКАЯ ПРОБЛЕМА ОБНАРУЖЕНА
+
+### Текущее состояние системы
+
+**Что работает:**
+- ✅ Python webhook server получает события от RingCentral
+- ✅ WebPhone Bridge регистрируется в RingCentral (Device ID: 805325563019)
+- ✅ SIP регистрация проходит успешно
+- ✅ Входящие звонки обнаруживаются через webhook события
+- ✅ WebSocket соединение с RingCentral активно
+
+**Что НЕ работает:**
+- ❌ WebPhone использует MOCK реализации WebRTC
+- ❌ Нет реального аудио потока
+- ❌ MockRTCPeerConnection вместо настоящего WebRTC
+- ❌ MockMediaStream вместо реального медиа потока
+- ❌ Звонки принимаются, но без реального аудио
+
+### Корневая причина проблемы
+
+**RingCentral WebPhone SDK предназначен для работы в БРАУЗЕРЕ, а не в Node.js!**
+
+Текущая реализация использует полифиллы (заглушки) для WebRTC API:
+```javascript
+// Это НЕ настоящий WebRTC, а просто заглушка!
+global.RTCPeerConnection = MockRTCPeerConnection;
+global.MediaStream = MockMediaStream;
+```
+
+## 📚 Анализ официальной документации
+
+### RingCentral WebPhone SDK
+- **Официальный GitHub**: https://github.com/ringcentral/ringcentral-web-phone
+- **Требование**: Браузерное окружение с поддержкой WebRTC
+- **НЕ поддерживает**: Прямое использование в Node.js
+
+### Из документации RingCentral:
+> "WebPhone SDK is designed to work in web browsers that support WebRTC"
+
+## 🛠️ РЕШЕНИЯ
+
+### Вариант 1: Puppeteer/Playwright (РЕКОМЕНДУЕТСЯ)
+
+Запустить WebPhone в настоящем браузере через Puppeteer:
+
+```javascript
+const puppeteer = require('puppeteer');
+
+async function startWebPhoneBrowser() {
+    const browser = await puppeteer.launch({
+        headless: 'new', // или false для отладки
+        args: [
+            '--use-fake-ui-for-media-stream',
+            '--use-fake-device-for-media-stream',
+            '--allow-file-access',
+            '--disable-web-security'
+        ]
+    });
+    
+    const page = await browser.newPage();
+    
+    // Разрешить доступ к микрофону
+    const context = browser.defaultBrowserContext();
+    await context.overridePermissions('https://localhost', ['microphone']);
+    
+    // Загрузить HTML страницу с WebPhone
+    await page.goto('file://' + __dirname + '/webphone.html');
+    
+    // Инжектировать конфигурацию
+    await page.evaluate((config) => {
+        window.RINGCENTRAL_CONFIG = config;
+    }, {
+        clientId: process.env.RINGCENTRAL_CLIENT_ID,
+        jwtToken: process.env.RINGCENTRAL_JWT_TOKEN
+    });
+    
+    // Запустить WebPhone в браузере
+    await page.evaluate(() => {
+        // Здесь будет настоящий WebPhone с реальным WebRTC
+        window.initializeWebPhone();
+    });
+}
+```
+
+### Вариант 2: Electron (для десктоп приложения)
+
+```javascript
+const { app, BrowserWindow } = require('electron');
+
+function createWindow() {
+    const win = new BrowserWindow({
+        width: 800,
+        height: 600,
+        webPreferences: {
+            nodeIntegration: true,
+            contextIsolation: false
+        }
+    });
+    
+    win.loadFile('webphone.html');
+}
+
+app.whenReady().then(createWindow);
+```
+
+### Вариант 3: RingCentral Call Control API (БЕЗ WebPhone)
+
+Использовать REST API для управления звонками:
+
+```javascript
+// Ответить на звонок через REST API
+async function answerCall(telephonySessionId, partyId) {
+    const response = await platform.post(
+        `/restapi/v1.0/account/~/telephony/sessions/${telephonySessionId}/parties/${partyId}/answer`,
+        {
+            deviceId: deviceId
+        }
+    );
+    return response.json();
+}
+
+// Получить аудио через RingCentral Recording API
+async function getCallRecording(recordingId) {
+    const response = await platform.get(
+        `/restapi/v1.0/account/~/recording/${recordingId}`
+    );
+    return response.blob();
+}
+```
+
+## 🎯 РЕКОМЕНДУЕМОЕ РЕШЕНИЕ
+
+### Архитектура с Puppeteer:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Node.js процесс                        │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │            Puppeteer Controller                  │    │
+│  │  - Управляет браузером                          │    │
+│  │  - Передает конфигурацию                        │    │
+│  │  - Слушает события от браузера                  │    │
+│  └─────────────────────┬───────────────────────────┘    │
+│                        │                                 │
+│  ┌─────────────────────▼───────────────────────────┐    │
+│  │          Headless Chrome Browser                │    │
+│  │  ┌───────────────────────────────────────┐     │    │
+│  │  │        RingCentral WebPhone           │     │    │
+│  │  │   - Настоящий WebRTC                  │     │    │
+│  │  │   - Реальные MediaStream              │     │    │
+│  │  │   - Полноценный SIP клиент           │     │    │
+│  │  └───────────────────────────────────────┘     │    │
+│  └─────────────────────────────────────────────────┘    │
+│                                                          │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │            WebSocket Bridge                     │    │
+│  │  - Передает аудио в Python AI                   │    │
+│  └─────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 📝 ПЛАН МИГРАЦИИ
+
+1. **Установить Puppeteer**:
+   ```bash
+   npm install puppeteer
+   ```
+
+2. **Создать HTML страницу для WebPhone**:
+   ```html
+   <!DOCTYPE html>
+   <html>
+   <head>
+       <script src="https://unpkg.com/@ringcentral/sdk/dist/ringcentral.js"></script>
+       <script src="https://unpkg.com/ringcentral-web-phone/dist/ringcentral-web-phone.js"></script>
+   </head>
+   <body>
+       <script src="webphone-browser.js"></script>
+   </body>
+   </html>
+   ```
+
+3. **Создать браузерный скрипт** (webphone-browser.js):
+   ```javascript
+   async function initializeWebPhone() {
+       const sdk = new RingCentral.SDK({
+           clientId: window.RINGCENTRAL_CONFIG.clientId,
+           server: 'https://platform.ringcentral.com'
+       });
+       
+       await sdk.login({ jwt: window.RINGCENTRAL_CONFIG.jwtToken });
+       
+       const webPhone = new RingCentral.WebPhone(sdk, {
+           appName: 'VoiceAI',
+           appVersion: '1.0.0',
+           audioHelper: {
+               enabled: true
+           }
+       });
+       
+       await webPhone.register();
+       
+       webPhone.on('call', (session) => {
+           session.accept();
+           // Передать аудио поток в Node.js через WebSocket
+       });
+   }
+   ```
+
+4. **Модифицировать Node.js контроллер** для работы с Puppeteer
+
+## ⚠️ ВАЖНЫЕ МОМЕНТЫ
+
+1. **Mock реализации НЕ РАБОТАЮТ** для реальных звонков
+2. **WebPhone ТРЕБУЕТ браузерное окружение** с WebRTC
+3. **Puppeteer - проверенное решение** для запуска WebPhone в headless режиме
+4. **Альтернатива**: использовать Call Control API без WebPhone
+
+## 🆘 ТЕКУЩИЕ ЛОГИ ПОКАЗЫВАЮТ
+
+```
+🔧 MockMediaDevices: getUserMedia вызван
+🔧 MockMediaStreamTrack: создан audio track
+🔧 MockRTCPeerConnection: addTrack вызван
+🔊 Starting audio stream simulation...
+🎵 Audio stream active, simulating RTP packets...
+```
+
+**Это НЕ реальный аудио поток!** Это просто симуляция для того, чтобы WebPhone не выдавал ошибки.
+
+## ✅ ЗАКЛЮЧЕНИЕ
+
+**Текущая реализация с Mock объектами НЕ МОЖЕТ обрабатывать реальные звонки.**
+
+Необходимо:
+1. Либо использовать Puppeteer/Playwright для запуска WebPhone в настоящем браузере
+2. Либо отказаться от WebPhone и использовать Call Control API
+3. Либо создать отдельный сервис на Electron для обработки WebRTC
+
+---
+
+**Письмо в будущее:** Клод, если ты видишь это сообщение - WebPhone НЕ РАБОТАЕТ в Node.js с полифиллами! Нужен настоящий браузер с WebRTC. Используй Puppeteer или Call Control API.


### PR DESCRIPTION
Documented that RingCentral WebPhone SDK requires a real browser environment, as current Node.js mock WebRTC polyfills prevent actual audio processing.

The existing WebPhone Bridge attempts to run the RingCentral WebPhone SDK directly in Node.js using mock WebRTC polyfills. This setup, while appearing to initialize, only simulates audio streams and cannot handle real-time voice communication. This PR introduces a detailed analysis explaining this limitation and outlines recommended solutions, primarily leveraging Puppeteer for a headless browser environment, to enable functional WebRTC.

---
<a href="https://cursor.com/background-agent?bcId=bc-936da927-4fb3-418e-814f-59f249479dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-936da927-4fb3-418e-814f-59f249479dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

